### PR TITLE
Add -H option for defining HTTP request headers

### DIFF
--- a/cmd/lift/cmd/root.go
+++ b/cmd/lift/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/bjwschaap/lift/pkg/lift"
 	homedir "github.com/mitchellh/go-homedir"
@@ -37,7 +38,20 @@ var (
 				log.SetFormatter(&log.JSONFormatter{})
 			}
 
-			lift, err := lift.New(viper.GetString("alpine-data-url"))
+			headers := make(map[string][]string)
+			for _, h := range viper.GetStringSlice("request-headers") {
+				words := strings.SplitN(h, ":", 2)
+				key := strings.TrimSpace(words[0])
+				value := strings.TrimSpace(words[1])
+				if key == "" || value == "" {
+					log.Errorf("Invalid request header: %s", h)
+					log.Error("Lift aborted")
+					os.Exit(1)
+				}
+				headers[key] = append(headers[key], value)
+			}
+
+			lift, err := lift.New(viper.GetString("alpine-data-url"), headers)
 			if err != nil {
 				log.Error(err)
 				log.Error("Lift aborted")
@@ -61,6 +75,7 @@ var (
 
 	cfgFile string
 	dataURL string
+	headers []string
 	debug   bool
 	json    bool
 	nocolor bool
@@ -79,8 +94,10 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&nocolor, "no-color", false, "disable colors in logging")
 	RootCmd.PersistentFlags().BoolVarP(&json, "json", "j", false, "Log output in JSON format")
 	RootCmd.PersistentFlags().StringVarP(&dataURL, "alpine-data-url", "s", "", "URL to download alpine-data")
+	RootCmd.PersistentFlags().StringArrayVarP(&headers, "request-header", "H", nil, "HTTP header(s) to include in request, akin to curl's -H")
 	_ = viper.BindPFlag("debug", RootCmd.PersistentFlags().Lookup("debug"))
 	_ = viper.BindPFlag("alpine-data-url", RootCmd.PersistentFlags().Lookup("alpine-data-url"))
+	_ = viper.BindPFlag("request-header", RootCmd.PersistentFlags().Lookup("request-header"))
 	_ = viper.BindPFlag("json", RootCmd.PersistentFlags().Lookup("json"))
 	_ = viper.BindPFlag("no-color", RootCmd.PersistentFlags().Lookup("no-color"))
 }

--- a/pkg/lift/download.go
+++ b/pkg/lift/download.go
@@ -6,8 +6,13 @@ import (
 )
 
 // DownloadFile returns a file from http(s)
-func downloadFile(url string) ([]byte, error) {
-	resp, err := http.Get(url)
+func downloadFile(url string, headers http.Header) ([]byte, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = headers
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lift/execute.go
+++ b/pkg/lift/execute.go
@@ -386,7 +386,7 @@ func (l *Lift) drpSetup() error {
 	if _, err := os.Stat(drpcliBin); os.IsNotExist(err) {
 		url := fmt.Sprintf("%s/drpcli.amd64.linux", l.Data.DRP.AssetsURL)
 		log.WithField("url", url).Debug("Downloading drpcli")
-		drpcli, err := downloadFile(url)
+		drpcli, err := downloadFile(url, nil)
 		if err != nil {
 			return err
 		}
@@ -510,7 +510,7 @@ func (l *Lift) createFiles() error {
 			data = []byte(wf.Content)
 
 		} else if wf.ContentURL != "" {
-			if data, err = downloadFile(wf.ContentURL); err != nil {
+			if data, err = downloadFile(wf.ContentURL, nil); err != nil {
 				return err
 			}
 		}

--- a/pkg/lift/main.go
+++ b/pkg/lift/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,15 +15,17 @@ import (
 
 // Lift contains all configuration
 type Lift struct {
-	DataURL string
-	Data    *AlpineData
+	DataURL        string
+	RequestHeaders http.Header
+	Data           *AlpineData
 }
 
 // New returns a new Lift instance with initial configuration
-func New(dataURL string) (*Lift, error) {
+func New(dataURL string, requestHeaders http.Header) (*Lift, error) {
 	return &Lift{
-		DataURL: dataURL,
-		Data:    InitAlpineData(),
+		DataURL:        dataURL,
+		RequestHeaders: requestHeaders,
+		Data:           InitAlpineData(),
 	}, nil
 }
 
@@ -51,7 +54,7 @@ func (l *Lift) Start() error {
 		}
 	}
 	log.WithField("url", l.DataURL).Info("downloading alpine-data file")
-	data, err := downloadFile(l.DataURL)
+	data, err := downloadFile(l.DataURL, l.RequestHeaders)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some metadata endpoints (such as GCP's) require specific HTTP request
headers. Support this case by accepting curl-style -H options to add
HTTP headers to the request.

Reference: https://cloud.google.com/compute/docs/storing-retrieving-metadata#querying