### PR TITLE
complete repo rename -> alpine-lift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PKG = github.com/bjwschaap/lift
+PKG = github.com/bjwschaap/alpine-lift
 BINNAME = lift
 VERSION = v0.0.1
 GOOS = -e GOOS=linux
@@ -6,7 +6,7 @@ GOARCH = -e GOARCH=amd64
 CGO = -e CGO_ENABLED=1
 BUILDIMAGE = golang:1.11.4-alpine
 DOCKERRUN = docker run --rm -t -v ${SRC}:/go/src/${PKG} -w /go/src/${PKG} ${GOOS} ${GOARCH} ${CGO} ${BUILDIMAGE}
-GOBUILD = GO111MODULE=on go build -a -tags netgo -ldflags '-s -w -extldflags "-static" -X github.com/bjwschaap/lift/cmd/lift/cmd.gitTag=${GITTAG} -X github.com/bjwschaap/lift/cmd/lift/cmd.buildUser=${USER} -X github.com/bjwschaap/lift/cmd/lift/cmd.version=${VERSION} -X github.com/bjwschaap/lift/cmd/lift/cmd.buildDate=${BUILDDATE}'
+GOBUILD = GO111MODULE=on go build -a -tags netgo -ldflags '-s -w -extldflags "-static" -X github.com/bjwschaap/alpine-lift/cmd/lift/cmd.gitTag=${GITTAG} -X github.com/bjwschaap/alpine-lift/cmd/lift/cmd.buildUser=${USER} -X github.com/bjwschaap/alpine-lift/cmd/lift/cmd.version=${VERSION} -X github.com/bjwschaap/alpine-lift/cmd/lift/cmd.buildDate=${BUILDDATE}'
 UPX = upx --brute bin/${BINNAME}
 BUILDDATE = $(shell date '+%Y%m%d-%H%M')
 GITTAG = $(shell git rev-parse --short HEAD)
@@ -19,13 +19,13 @@ GOFILES = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 all: clean upxbuild
 
 build:
-	${DOCKERRUN} ash -c "apk add --no-cache git upx libc-dev gcc && GO111MODULE=on go mod download && ${GOBUILD} -o bin/${BINNAME} github.com/bjwschaap/lift/cmd/lift"
+	${DOCKERRUN} ash -c "apk add --no-cache git upx libc-dev gcc && GO111MODULE=on go mod download && ${GOBUILD} -o bin/${BINNAME} github.com/bjwschaap/alpine-lift/cmd/lift"
 
 upxbuild:
-	${DOCKERRUN} ash -c "apk add --no-cache git upx libc-dev gcc && GO111MODULE=on go mod download && ${GOBUILD} -o bin/${BINNAME} github.com/bjwschaap/lift/cmd/lift && ${UPX}"
+	${DOCKERRUN} ash -c "apk add --no-cache git upx libc-dev gcc && GO111MODULE=on go mod download && ${GOBUILD} -o bin/${BINNAME} github.com/bjwschaap/alpine-lift/cmd/lift && ${UPX}"
 
 localbuild:
-	${GOBUILD} -v -race -o bin/${BINNAME} github.com/bjwschaap/lift/cmd/lift
+	${GOBUILD} -v -race -o bin/${BINNAME} github.com/bjwschaap/alpine-lift/cmd/lift
 
 upx:
 	${UPX}

--- a/cmd/lift/cmd/root.go
+++ b/cmd/lift/cmd/root.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/bjwschaap/lift/pkg/lift"
+	"github.com/bjwschaap/alpine-lift/pkg/lift"
 	homedir "github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cmd/lift/main.go
+++ b/cmd/lift/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bjwschaap/lift/cmd/lift/cmd"
+	"github.com/bjwschaap/alpine-lift/cmd/lift/cmd"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bjwschaap/lift
+module github.com/bjwschaap/alpine-lift
 
 require (
 	github.com/docker/docker v1.13.1
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.7.1
+	github.com/stretchr/objx v0.1.1 // indirect
 	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	gopkg.in/ini.v1 v1.57.0 // indirect


### PR DESCRIPTION
alpine-lift is not installable today via `go get` because its repository
name no longer matches the name given for it in `go.mod`. Fix this by
updating all names in the package to refer to the name of the repo
on github.com.