### PR TITLE
Support YAML that has no values set

### DIFF
--- a/pkg/lift/execute.go
+++ b/pkg/lift/execute.go
@@ -311,6 +311,9 @@ func (l *Lift) rootPasswdSetup() error {
 
 // parses sshd_config, writes authorized_keys file and restarts sshd service
 func (l *Lift) sshdSetup() error {
+	if l.Data.SSHDConfig == nil {
+		return nil
+	}
 	if err := parseConfigFile("/etc/ssh/sshd_config", " ", l.getSSHDKVMap()); err != nil {
 		return err
 	}
@@ -430,6 +433,9 @@ func (l *Lift) drpSetup() error {
 }
 
 func (l *Lift) setupAPK() error {
+	if l.Data.Packages == nil {
+		return nil
+	}
 	rfile, err := generateFileFromTemplate(*repoFile, l.Data.Packages.Repositories)
 	if err != nil {
 		return err

--- a/pkg/lift/main.go
+++ b/pkg/lift/main.go
@@ -75,24 +75,31 @@ func (l *Lift) Start() error {
 		return err
 	}
 
-	log.Info("Setting Hostname")
-	if err = l.setHostname(); err != nil {
-		return err
-	}
+	if l.Data.Network != nil {
+		log.Info("Setting Hostname")
+		if err = l.setHostname(); err != nil {
+			return err
+		}
 
-	log.Info("Setup Network Interfaces")
-	if err = l.networkSetup(); err != nil {
-		return err
-	}
+		log.Info("Setup Network Interfaces")
+		if err = l.networkSetup(); err != nil {
+			return err
+		}
 
-	log.Info("Setup DNS")
-	if err = l.dnsSetup(); err != nil {
-		return err
-	}
+		log.Info("Setup DNS")
+		if err = l.dnsSetup(); err != nil {
+			return err
+		}
 
-	log.Info("Setup Up Network Proxy")
-	if err = l.proxySetup(); err != nil {
-		return err
+		log.Info("Setup Up Network Proxy")
+		if err = l.proxySetup(); err != nil {
+			return err
+		}
+
+		log.Info("Setup NTP")
+		if err = l.ntpSetup(); err != nil {
+			return err
+		}
 	}
 
 	log.Info("Setup APK and Packages")
@@ -122,12 +129,7 @@ func (l *Lift) Start() error {
 		}
 	}
 
-	log.Info("Setup NTP")
-	if err = l.ntpSetup(); err != nil {
-		return err
-	}
-
-	if l.Data.DRP.InstallRunner {
+	if l.Data.DRP != nil && l.Data.DRP.InstallRunner {
 		log.Info("Installing dr-provision runner")
 		if err = l.drpSetup(); err != nil {
 			return err


### PR DESCRIPTION
Update lift.Start() and its dependencies to tolerate YAML that has no
network, packages, or SSH configuration. This also makes it so that lift
runs as advertised in the README, using the sample, nearly empty YAML
without panics.

Note that NTP setup was pulled up into the same setup block as all other
network dependent functions.