### PR TITLE
README: add instruction for building with make

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ YAML file equivalent to cloud-init's user-data. Lift will download the
 alpine-data and perform the initial OS configuration. Lift will run only once,
 on first boot of the system, by default.
 
+## Building
+
+To make a statically linked, upx-compressed build suitable for any
+recent Alpine version, run:
+
+```
+make
+```
+
 ## Usage
 
 In order for `lift` to bootstrap your Alpine node:


### PR DESCRIPTION
Just that! Seemed like it might make adoption a bit easier for people, since the `Makefile` does some nice work to make the binary smaller between upx and a few build flags, too.